### PR TITLE
Remove additional Error or Done from cdflow output

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -180,9 +180,9 @@ def docker_run(
 def handle_finished_container(container):
     container.reload()
     exit_status = container.attrs['State']['ExitCode']
-    output = 'Done'
+    output = ''
     if exit_status != 0:
-        output = 'Error'
+        output = ''
     return exit_status, output
 
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -121,7 +121,7 @@ class TestDockerRun(unittest.TestCase):
         )
 
         assert exit_status == 0
-        assert output == 'Done'
+        assert output == ''
 
         docker_client.containers.run.assert_called_once_with(
             image_id,
@@ -181,7 +181,7 @@ class TestDockerRun(unittest.TestCase):
         )
 
         assert exit_status == 0
-        assert output == 'Done'
+        assert output == ''
 
         docker_client.containers.run.assert_called_once_with(
             image_id,
@@ -366,4 +366,4 @@ class TestDockerRun(unittest.TestCase):
         )
 
         assert exit_status == fixtures['exit_code']
-        assert output == 'Error'
+        assert output == ''


### PR DESCRIPTION
This removes the string "Error" from the output, which was being
displayed with the usage message, and removes the "Done" string
otherwise - the user being presented with a prompt and a zero exit
status should be enough to signal that the process is done. This also
makes it a thinner wrapper around the cdflow container.