### PR TITLE
Adding the logentries env var to release

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -57,6 +57,7 @@ class TestIntegration(unittest.TestCase):
                 'ROLE_SESSION_NAME': ANY,
                 'CDFLOW_IMAGE_DIGEST': 'hash',
                 'JOB_NAME': ANY,
+                'LOGENTRIES_ACCOUNT_KEY': ANY,
             },
             detach=True,
             volumes={
@@ -138,6 +139,7 @@ class TestIntegration(unittest.TestCase):
                 'ROLE_SESSION_NAME': ANY,
                 'CDFLOW_IMAGE_DIGEST': 'hash',
                 'JOB_NAME': ANY,
+                'LOGENTRIES_ACCOUNT_KEY': ANY,
             },
             detach=True,
             volumes={


### PR DESCRIPTION
We added logentries functionality to cdflow as part of PLAT-1100. This
is simply to update the tests.