### PR TITLE
Fixing the long format flag component name

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -95,7 +95,7 @@ def _get_component_name_from_cli_args(argv):
     component_flag_index = None
     for flag in ('-c', '--component'):
         try:
-            component_flag_index = argv.index('-c')
+            component_flag_index = argv.index(flag)
         except ValueError:
             pass
     if component_flag_index > -1:

--- a/test/test_fetch_release.py
+++ b/test/test_fetch_release.py
@@ -20,20 +20,22 @@ class TestGetComponentName(unittest.TestCase):
     @given(text(
         alphabet=VALID_ALPHABET, min_size=1, max_size=100
     ))
-    def test_get_component_name_passed_in(self, component_name):
-        argv = ['deploy', '42', '-c', component_name]
-        component_name = get_component_name(argv)
+    def test_get_component_name_passed_in(self, expected_component_name):
+        argv = ['deploy', '42', '-c', expected_component_name]
+        actual_component_name = get_component_name(argv)
 
-        assert component_name == component_name
+        assert actual_component_name == expected_component_name
 
     @given(text(
         alphabet=VALID_ALPHABET, min_size=1, max_size=100
     ))
-    def test_get_component_name_passed_in_with_long_flag(self, component_name):
-        argv = ['deploy', '42', '--component', component_name]
-        component_name = get_component_name(argv)
+    def test_get_component_name_passed_in_with_long_flag(
+        self, expected_component_name
+    ):
+        argv = ['deploy', '42', '--component', expected_component_name]
+        actual_component_name = get_component_name(argv)
 
-        assert component_name == component_name
+        assert actual_component_name == expected_component_name
 
     @given(text(
         alphabet=VALID_ALPHABET, min_size=1, max_size=100


### PR DESCRIPTION
We were only checking the short flag format so it was causing the
--component not to work on deploy.

The test was also checking component_name == component_name, so fixed that too.