### PR TITLE
Changes encoding message so it works with python3

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -194,7 +194,7 @@ def _print_logs(container):
     for message in container.logs(
         stream=True, follow=True, stdout=True, stderr=True
     ):
-        print(message, end='')
+        print(message.decode(), end='')
 
 
 def _remove_container(container):


### PR DESCRIPTION
The tests showed that the output from terraform was not printing out in the nicest format. Adding encoding means that it'll output correctly when running with python3.