### PR TITLE
Adding a CDFLOW_TEST_LOCAL var to stop pull

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -141,12 +141,15 @@ def _get_release_storage_key(component_name, version):
 
 
 def get_image_sha(docker_client, image_id):
-    logger.info('Pulling image {}'.format(image_id))
-    try:
-        image = docker_client.images.pull(image_id)
-    except ImageNotFound as e:
-        logger.exception(e)
+    if 'CDFLOW_TEST_LOCAL' in os.environ:
         image = docker_client.images.get(image_id)
+    else:
+        logger.info('Pulling image {}'.format(image_id))
+        try:
+            image = docker_client.images.pull(image_id)
+        except ImageNotFound as e:
+            logger.exception(e)
+            image = docker_client.images.get(image_id)
     digests = image.attrs['RepoDigests']
     return digests[0] if len(digests) else image_id
 

--- a/cdflow.py
+++ b/cdflow.py
@@ -141,7 +141,7 @@ def _get_release_storage_key(component_name, version):
 
 
 def get_image_sha(docker_client, image_id):
-    if 'CDFLOW_TEST_LOCAL' in os.environ:
+    if 'CDFLOW_NO_IMAGE_PULL' in os.environ:
         image = docker_client.images.get(image_id)
     else:
         logger.info('Pulling image {}'.format(image_id))

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -78,6 +78,24 @@ class TestImage(unittest.TestCase):
 
         assert fetched_image_sha == image_id
 
+    @given(image_id())
+    def test_do_not_pull_for_local_image(self, image_id):
+        with patch('cdflow.os') as os:
+            os.environ = {"CDFLOW_TEST_LOCAL": "true"}
+            docker_client = MagicMock(spec=DockerClient)
+
+            image = MagicMock(spec=Image)
+            image.attrs = {
+                'RepoDigests': []
+            }
+
+            docker_client.images.get.return_value = image
+
+            fetched_image_sha = get_image_sha(docker_client, image_id)
+
+            assert docker_client.images.pull.call_count == 0
+            assert fetched_image_sha == image_id
+
 
 class TestDockerRun(unittest.TestCase):
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -81,7 +81,7 @@ class TestImage(unittest.TestCase):
     @given(image_id())
     def test_do_not_pull_for_local_image(self, image_id):
         with patch('cdflow.os') as os:
-            os.environ = {"CDFLOW_TEST_LOCAL": "true"}
+            os.environ = {"CDFLOW_NO_IMAGE_PULL": "true"}
             docker_client = MagicMock(spec=DockerClient)
 
             image = MagicMock(spec=Image)


### PR DESCRIPTION
We want to add this var to overwrite the docker pull and instead only
check locally for an docker image. This will be useful when running
tests against a local version of cdflow-commands.