### PR TITLE
Updating the implementation to check empty value

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -141,7 +141,7 @@ def _get_release_storage_key(component_name, version):
 
 
 def get_image_sha(docker_client, image_id):
-    if 'CDFLOW_NO_IMAGE_PULL' in os.environ:
+    if os.getenv('CDFLOW_NO_IMAGE_PULL', False):
         image = docker_client.images.get(image_id)
     else:
         logger.info('Pulling image {}'.format(image_id))

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -81,7 +81,25 @@ class TestImage(unittest.TestCase):
     @given(image_id())
     def test_do_not_pull_for_local_image(self, image_id):
         with patch('cdflow.os') as os:
-            os.environ = {"CDFLOW_NO_IMAGE_PULL": "true"}
+            os.environ = {'CDFLOW_NO_IMAGE_PULL': 'true'}
+            docker_client = MagicMock(spec=DockerClient)
+
+            image = MagicMock(spec=Image)
+            image.attrs = {
+                'RepoDigests': []
+            }
+
+            docker_client.images.get.return_value = image
+
+            fetched_image_sha = get_image_sha(docker_client, image_id)
+
+            assert docker_client.images.pull.call_count == 0
+            assert fetched_image_sha == image_id
+
+    @given(image_id())
+    def test_do_not_pull_for_empty_var(self, image_id):
+        with patch('cdflow.os') as os:
+            os.environ = {'CDFLOW_NO_IMAGE_PULL': ''}
             docker_client = MagicMock(spec=DockerClient)
 
             image = MagicMock(spec=Image)


### PR DESCRIPTION
When we use cdflow in the tests we pass the var through as empty meaning
we want to check that it's empty not that the key exists.