### PR TITLE
Python 3 fix

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -92,7 +92,7 @@ def get_component_name(argv):
 
 
 def _get_component_name_from_cli_args(argv):
-    component_flag_index = None
+    component_flag_index = -1
     for flag in ('-c', '--component'):
         try:
             component_flag_index = argv.index(flag)


### PR DESCRIPTION
Error in line: https://github.com/mergermarket/cdflow/pull/24/files#diff-06ff66b3a74b8c6b7eab605797b0ca76R101

TypeError: '>' not supported between instances of 'str' and 'int'

