### PR TITLE
Add option to validate the wrapper

### DIFF
--- a/test/test_fetch_release.py
+++ b/test/test_fetch_release.py
@@ -182,14 +182,19 @@ class TestGetPlatformConfigPathFromArgs(unittest.TestCase):
 
     @given(filepath(), filepath())
     def test_get_config_path_from_args(self, path_a, path_b):
-        args = [
-            'release',
-            '--platform-config', path_a,
-            '--platform-config={}'.format(path_b),
-            '42'
-        ]
+        with patch('cdflow.abspath') as abspath:
+            prefix = '/a/path'
+            abspath.side_effect = lambda path: '{}/{}'.format(prefix, path)
+            args = [
+                'release',
+                '--platform-config', path_a,
+                '--platform-config={}'.format(path_b),
+                '42'
+            ]
 
-        assert get_platform_config_paths(args) == [path_a, path_b]
+            assert get_platform_config_paths(args) == [
+                '{}/{}'.format(prefix, path_a), '{}/{}'.format(prefix, path_b)
+            ]
 
     def test_raises_exception_when_missing_flag(self):
         self.assertRaises(

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -21,7 +21,10 @@ class TestIntegration(unittest.TestCase):
         argv = ['release', '--platform-config', '../path/to/config',
                 '--release-data ami_id=ami-z9876', '42']
         with patch('cdflow.docker') as docker, \
-                patch('cdflow.os') as os:
+                patch('cdflow.os') as os, \
+                patch('cdflow.abspath') as abspath:
+            abs_path_to_config = '/root/path/to/config'
+            abspath.return_value = abs_path_to_config
 
             image = MagicMock(spec=Image)
             docker.from_env.return_value.images.pull.return_value = image
@@ -37,8 +40,6 @@ class TestIntegration(unittest.TestCase):
 
             os.getcwd.return_value = project_root
             os.getenv.return_value = False
-            abs_path_to_config = '/root/path/to/config'
-            os.path.abspath.return_value = abs_path_to_config
 
             exit_status = main(argv)
 
@@ -104,7 +105,10 @@ class TestIntegration(unittest.TestCase):
         environment['CDFLOW_IMAGE_ID'] = pinned_image_id
 
         with patch('cdflow.docker') as docker, \
-                patch('cdflow.os') as os:
+                patch('cdflow.os') as os, \
+                patch('cdflow.abspath') as abspath:
+            abs_path_to_config = '/root/path/to/config'
+            abspath.return_value = abs_path_to_config
 
             image = MagicMock(spec=Image)
             docker.from_env.return_value.images.pull.return_value = image
@@ -120,8 +124,6 @@ class TestIntegration(unittest.TestCase):
 
             os.getcwd.return_value = project_root
             os.getenv.return_value = False
-            abs_path_to_config = '/root/path/to/config'
-            os.path.abspath.return_value = abs_path_to_config
 
             os.environ = environment
 


### PR DESCRIPTION
This is so that we can run the wrapper when we build the cdflow-builder
container to validate installation, without running the cdflow-commands
container itself.