### PR TITLE
Add a build script to produce a single executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.15 AS base
+FROM python:3.7.1 AS base
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM centos:7.5.1804
-
-RUN yum install -y epel-release 
-RUN yum install -y git python-pip
-RUN pip install -U pip
+FROM python:2.7.15 AS base
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt
@@ -13,3 +9,10 @@ ENV PYTHONPATH /cdflow/
 WORKDIR /cdflow/
 
 COPY . .
+
+FROM base AS build
+
+RUN pip install pyinstaller
+
+RUN pyinstaller --onefile cdflow.py && \
+    pyinstaller cdflow.spec

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_ID="$(basename $(pwd))-build"
+
+docker image build -t "${IMAGE_ID}" --target=build .
+
+docker container run --rm --name "${IMAGE_ID}" \
+    -i $(tty -s && echo -t) \
+    -d \
+    "${IMAGE_ID}"
+    
+docker container cp "${IMAGE_ID}:/cdflow/dist/cdflow" .
+
+docker container rm --force "${IMAGE_ID}"

--- a/cdflow.py
+++ b/cdflow.py
@@ -218,7 +218,7 @@ def _print_logs(container):
     for message in container.logs(
         stream=True, follow=True, stdout=True, stderr=True
     ):
-        print(message.decode('utf-8'), end='')
+        print(message, end='')
 
 
 def _remove_container(container):

--- a/cdflow.py
+++ b/cdflow.py
@@ -218,7 +218,7 @@ def _print_logs(container):
     for message in container.logs(
         stream=True, follow=True, stdout=True, stderr=True
     ):
-        print(message, end='')
+        print(message.decode('utf-8'), end='')
 
 
 def _remove_container(container):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3
-docker==3.5.1
+docker
 PyYAML

--- a/test.sh
+++ b/test.sh
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-image_id="$(basename $(pwd))"
+image_id="$(basename $(pwd))-test"
 
-docker build -t "${image_id}" .
+docker image build -t "${image_id}" --target=base .
 
-docker run --rm --name "${image_id}" \
+docker container run --rm --name "${image_id}" \
     -i $(tty -s && echo -t) \
     "${image_id}" \
     py.test \

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -111,7 +111,7 @@ class TestFetchAccountScheme(unittest.TestCase):
             'default-region', 'ecr-registry', 'lambda-bucket'
         ])
 
-        assert map(str, sorted(account_scheme.keys())) == expected_keys
+        assert list(sorted(account_scheme.keys())) == expected_keys
 
         release_bucket = '{}-account-resources'.format(account_prefix)
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -297,7 +297,7 @@ class TestDockerRun(unittest.TestCase):
 
         container = MagicMock(spec=Container)
         logs = MagicMock()
-        messages = ['Running', 'the', 'command']
+        messages = [m.encode('utf-8') for m in ('Running', 'the', 'command')]
         logs.__iter__.return_value = iter(messages)
         container.logs.return_value = logs
 
@@ -321,9 +321,12 @@ class TestDockerRun(unittest.TestCase):
             )
 
             assert print_.call_args_list[0][1]['end'] == ''
-            assert print_.call_args_list[0][0][0] == messages[0]
-            assert print_.call_args_list[1][0][0] == messages[1]
-            assert print_.call_args_list[2][0][0] == messages[2]
+            assert print_.call_args_list[0][0][0] == messages[0]\
+                .decode('utf-8')
+            assert print_.call_args_list[1][0][0] == messages[1]\
+                .decode('utf-8')
+            assert print_.call_args_list[2][0][0] == messages[2]\
+                .decode('utf-8')
 
     @given(fixed_dictionaries({
         'image_id': image_id(),

--- a/test/test_fetch_release.py
+++ b/test/test_fetch_release.py
@@ -44,7 +44,7 @@ class TestGetComponentName(unittest.TestCase):
         with patch('cdflow.check_output') as check_output:
             check_output.return_value = 'git@github.com:org/{}.git\n'.format(
                 component_name
-            )
+            ).encode('utf-8')
             extraced_component_name = get_component_name(self.argv)
 
             assert extraced_component_name == component_name
@@ -58,7 +58,7 @@ class TestGetComponentName(unittest.TestCase):
         with patch('cdflow.check_output') as check_output:
             check_output.return_value = 'git@github.com:org/{}\n'.format(
                 component_name
-            )
+            ).encode('utf-8')
             extraced_component_name = get_component_name(self.argv)
 
             assert extraced_component_name == component_name
@@ -72,7 +72,7 @@ class TestGetComponentName(unittest.TestCase):
         with patch('cdflow.check_output') as check_output:
             check_output.return_value = 'git@github.com:org/{}/\n'.format(
                 component_name
-            )
+            ).encode('utf-8')
             extraced_component_name = get_component_name(self.argv)
 
             assert extraced_component_name == component_name
@@ -87,7 +87,7 @@ class TestGetComponentName(unittest.TestCase):
             repo_template = 'https://github.com/org/{}.git\n'
             check_output.return_value = repo_template.format(
                 component_name
-            )
+            ).encode('utf-8')
             extraced_component_name = get_component_name(self.argv)
 
             assert extraced_component_name == component_name
@@ -101,7 +101,7 @@ class TestGetComponentName(unittest.TestCase):
         with patch('cdflow.check_output') as check_output:
             check_output.return_value = 'https://github.com/org/{}\n'.format(
                 component_name
-            )
+            ).encode('utf-8')
             extraced_component_name = get_component_name(self.argv)
 
             assert extraced_component_name == component_name

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,8 @@
 import json
 import unittest
+from unittest.mock import ANY, MagicMock, Mock, patch
 from string import printable
+from _io import TextIOWrapper
 
 import yaml
 from docker.client import DockerClient
@@ -10,7 +12,6 @@ from docker.models.images import Image
 from cdflow import CDFLOW_IMAGE_ID, main
 from hypothesis import given
 from hypothesis.strategies import dictionaries, fixed_dictionaries, lists, text
-from mock import ANY, MagicMock, Mock, patch
 from strategies import VALID_ALPHABET, filepath, image_id, s3_bucket_and_key
 
 
@@ -196,7 +197,7 @@ class TestIntegration(unittest.TestCase):
                 }}
             '''.format(fixtures['release_bucket'])
 
-            config_file = MagicMock(spec=file)
+            config_file = MagicMock(spec=TextIOWrapper)
             config_file.read.return_value = yaml.dump({
                 'account-scheme-url': 's3://{}/{}'.format(
                     *fixtures['s3_bucket_and_key']
@@ -277,7 +278,7 @@ class TestIntegration(unittest.TestCase):
                 }}
             '''.format(fixtures['release_bucket'])
 
-            config_file = MagicMock(spec=file)
+            config_file = MagicMock(spec=TextIOWrapper)
             config_file.read.return_value = yaml.dump({
                 'account-scheme-url': 's3://{}/{}'.format(
                     *fixtures['s3_bucket_and_key']
@@ -343,7 +344,7 @@ class TestIntegration(unittest.TestCase):
                 patch('cdflow.open') as open_:
 
             account_id = '1234567890'
-            config_file = MagicMock(spec=file)
+            config_file = MagicMock(spec=TextIOWrapper)
             config_file.read.return_value = json.dumps({
                 'platform_config': {'account_id': account_id}
             })


### PR DESCRIPTION
It would be really nice to have all of the dependencies for the cdflow wrapper bundled together to avoid a messy installation involving pip. This uses pyinstaller to do that.