### PR TITLE
Remove the CDFLOW_NO_IMAGE_PULL var

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -153,15 +153,17 @@ def _get_release_storage_key(team_name, component_name, version):
 
 
 def get_image_sha(docker_client, image_id):
-    if os.getenv('CDFLOW_NO_IMAGE_PULL', False):
+    logger.info('Pulling image {}'.format(image_id))
+    try:
+        image = docker_client.images.pull(image_id)
+    except ImageNotFound as e:
+        logger.debug(e)
+        logger.info(
+            'Could not pull image {}, trying to get it locally'.format(
+                image_id,
+            )
+        )
         image = docker_client.images.get(image_id)
-    else:
-        logger.info('Pulling image {}'.format(image_id))
-        try:
-            image = docker_client.images.pull(image_id)
-        except ImageNotFound as e:
-            logger.exception(e)
-            image = docker_client.images.get(image_id)
     digests = image.attrs['RepoDigests']
     return digests[0] if len(digests) else image_id
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -84,44 +84,6 @@ class TestImage(unittest.TestCase):
 
         assert fetched_image_sha == image_id
 
-    @settings(deadline=None)
-    @given(image_id())
-    def test_do_not_pull_for_local_image(self, image_id):
-        with patch('cdflow.os') as os:
-            os.environ = {'CDFLOW_NO_IMAGE_PULL': 'true'}
-            docker_client = MagicMock(spec=DockerClient)
-
-            image = MagicMock(spec=Image)
-            image.attrs = {
-                'RepoDigests': []
-            }
-
-            docker_client.images.get.return_value = image
-
-            fetched_image_sha = get_image_sha(docker_client, image_id)
-
-            assert docker_client.images.pull.call_count == 0
-            assert fetched_image_sha == image_id
-
-    @settings(deadline=None)
-    @given(image_id())
-    def test_do_not_pull_for_empty_var(self, image_id):
-        with patch('cdflow.os') as os:
-            os.environ = {'CDFLOW_NO_IMAGE_PULL': ''}
-            docker_client = MagicMock(spec=DockerClient)
-
-            image = MagicMock(spec=Image)
-            image.attrs = {
-                'RepoDigests': []
-            }
-
-            docker_client.images.get.return_value = image
-
-            fetched_image_sha = get_image_sha(docker_client, image_id)
-
-            assert docker_client.images.pull.call_count == 0
-            assert fetched_image_sha == image_id
-
 
 class TestDockerRun(unittest.TestCase):
 


### PR DESCRIPTION
This looks to have been to mask the exception so put that into a debug message, pending enabling debug level logging.