### PR TITLE
Install `staticx` and create a binary with it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,15 @@ COPY . .
 
 FROM base AS build
 
-RUN pip install pip==18.1 && pip install pyinstaller
+RUN pip install pip==18.1 && \
+    pip install pyinstaller staticx && \
+    apt-get update && apt-get install -y patchelf
 
 RUN pyinstaller \
     --hidden-import configparser \
     --onefile \
     --name "cdflow-$(uname -s)-$(uname -m)" \
     cdflow.py && \
-    pyinstaller "cdflow-$(uname -s)-$(uname -m).spec"
+    pyinstaller "cdflow-$(uname -s)-$(uname -m).spec" && \
+    staticx "./dist/cdflow-$(uname -s)-$(uname -m)" \
+        "cdflow-$(uname -s)-$(uname -m)" 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ def publish(githubCredentialsId) {
                     git push 'https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/mergermarket/cdflow' --tags
                 """
 
-                sh "./release.sh --repo_name mergermarket/cdflow --version ${nextVersion} --asset_path ./dist/cdflow-Linux-x86_64"
+                sh "./release.sh --repo_name mergermarket/cdflow --version ${nextVersion} --asset_path ./cdflow-Linux-x86_64"
             }
         }
     }


### PR DESCRIPTION
The `staticx` program bundles libc and other dynamically linked binaries. This means we can run `cdflow` under Alpine.