### PR TITLE
Check for `--component` flag before upgrading

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -325,7 +325,9 @@ def fetch_account_scheme(s3_resource, bucket, key, team, component):
         )
         return team in team_whitelist or component in component_whitelist
 
-    if upgrade and whitelisted(team, component):
+    component_flag_passed = _get_component_name_from_cli_args(sys.argv)
+
+    if not component_flag_passed and upgrade and whitelisted(team, component):
         bucket, key = parse_s3_url(upgrade['new-url'])
         logger.debug(
             'Account scheme forwarded, fetching from {}/{}'.format(


### PR DESCRIPTION
The `--component` flag is not supported by the release account scheme because resources are created ahead of running `cdflow`, so don't use the new account scheme. The `cdflow-commands` container will output a deprecation notice to the user.