### PR TITLE
Pass size of the external tty into the container

### DIFF
--- a/cdflow.py
+++ b/cdflow.py
@@ -201,6 +201,10 @@ def docker_run(
                 'mode': 'ro',
             }
         if _command(command) == 'shell':
+            columns = int(check_output(['tput', 'cols']))
+            lines = int(check_output(['tput', 'lines']))
+            environment_variables['COLUMNS'] = columns
+            environment_variables['LINES'] = lines
             container = docker_client.containers.create(
                 image_id,
                 command=command,


### PR DESCRIPTION
Workaround the issue in Docker where the terminal has a strange size:
https://github.com/moby/moby/issues/35407

This issue is purportedly fixed but I'm still seeing it.