### PR TITLE
Use simple team name in example

### DIFF
--- a/reference/cdflow-yaml.md
+++ b/reference/cdflow-yaml.md
@@ -20,5 +20,5 @@ These are the list of properties you can have in the cdflow manifest file. This 
 ```yaml
     account-scheme-url: s3://mmg-account-resources/account-scheme.json
     type: docker
-    team: DevTeam-Platform
+    team: platform
 ```


### PR DESCRIPTION
The example was using the format used in our groups, but general practice is to use a short name.