### PR TITLE
Fix for dockerhub pull limits problems

### DIFF
--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -114,7 +114,7 @@ class TestDockerRun(unittest.TestCase):
                 'ExitCode': 0
             }
         }
-        docker_client.containers.run.return_value = container
+        docker_client.containers.create.return_value = container
 
         exit_status, output = docker_run(
             docker_client,
@@ -145,7 +145,7 @@ class TestDockerRun(unittest.TestCase):
                 'mode': 'ro',
             }
 
-        docker_client.containers.run.assert_called_once_with(
+        docker_client.containers.create.assert_called_once_with(
             image_id,
             command=command,
             environment=environment_variables,
@@ -153,6 +153,8 @@ class TestDockerRun(unittest.TestCase):
             volumes=expected_volumes,
             working_dir=project_root,
         )
+
+        container.start.assert_called_once()
 
     @given(fixed_dictionaries({
         'environment_variables': fixed_dictionaries({
@@ -180,7 +182,7 @@ class TestDockerRun(unittest.TestCase):
                 'ExitCode': 0
             }
         }
-        docker_client.containers.run.return_value = container
+        docker_client.containers.create.return_value = container
 
         exit_status, output = docker_run(
             docker_client,
@@ -193,7 +195,7 @@ class TestDockerRun(unittest.TestCase):
         assert exit_status == 0
         assert output == ''
 
-        docker_client.containers.run.assert_called_once_with(
+        docker_client.containers.create.assert_called_once_with(
             image_id,
             command=command,
             environment=environment_variables,
@@ -210,6 +212,7 @@ class TestDockerRun(unittest.TestCase):
             },
             working_dir=project_root,
         )
+        container.start.assert_called_once()
 
     @given(fixed_dictionaries({
         'environment_variables': fixed_dictionaries({
@@ -303,7 +306,7 @@ class TestDockerRun(unittest.TestCase):
         environment_variables = fixtures['environment_variables']
 
         docker_client = MagicMock(spec=DockerClient)
-        docker_client.containers.run.side_effect = DockerException
+        docker_client.containers.create.side_effect = DockerException
 
         exit_status, output = docker_run(
             docker_client,
@@ -343,7 +346,7 @@ class TestDockerRun(unittest.TestCase):
             }
         }
 
-        docker_client.containers.run.return_value = container
+        docker_client.containers.create.return_value = container
 
         with patch('cdflow.print') as print_:
             docker_run(
@@ -384,7 +387,7 @@ class TestDockerRun(unittest.TestCase):
             }
         }
 
-        docker_client.containers.run.return_value = container
+        docker_client.containers.create.return_value = container
 
         with patch('cdflow.atexit') as atexit:
             docker_run(
@@ -441,7 +444,7 @@ class TestDockerRun(unittest.TestCase):
             }
         }
 
-        docker_client.containers.run.return_value = container
+        docker_client.containers.create.return_value = container
 
         exit_status, output = docker_run(
             docker_client, fixtures['image_id'], fixtures['command'],

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from unittest.mock import ANY, MagicMock, Mock, patch
 from string import printable
@@ -10,9 +9,9 @@ from docker.client import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 
-from cdflow import CDFLOW_IMAGE_ID, main, logger
+from cdflow import main, logger
 from hypothesis import given
-from hypothesis.strategies import dictionaries, fixed_dictionaries, lists, text
+from hypothesis.strategies import dictionaries, fixed_dictionaries, text
 
 from test.strategies import (
     VALID_ALPHABET, filepath, image_id, s3_bucket_and_key


### PR DESCRIPTION
If the user running cdflow has a .docker/config.json file in their home
directory, copy it into the cdflow-commands container prior to
launching it.

Copying it in rather than mounting it from the host allows anything in
container to add additional credentials to the file following subsequent
docker logins without causing other problems