### PR TITLE
Further fixes for docker hub pull limits

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -48,6 +48,7 @@ class TestIntegration(unittest.TestCase):
 
             os.getcwd.return_value = project_root
             os.getenv.return_value = False
+            os.environ.get
 
             config_file = MagicMock(spec=TextIOWrapper)
             config_file.read.return_value = yaml.dump({
@@ -60,7 +61,7 @@ class TestIntegration(unittest.TestCase):
 
         docker.from_env.assert_called_once()
         docker.from_env.return_value.images.pull.assert_called_once_with(
-            'mergermarket/cdflow-commands:latest'
+            'mergermarket/cdflow-commands:latest',
         )
         docker.from_env.return_value.containers.create.assert_called_once_with(
             'mergermarket/cdflow-commands:latest',
@@ -251,6 +252,7 @@ class TestIntegration(unittest.TestCase):
 
             project_root = fixtures['project_root']
             os.getcwd.return_value = project_root
+            os.getenv.return_value = False
 
             exit_status = main(argv)
 
@@ -351,6 +353,7 @@ class TestIntegration(unittest.TestCase):
 
             project_root = fixtures['project_root']
             os.getcwd.return_value = project_root
+            os.getenv.return_value = False
 
             exit_status = main(argv)
 


### PR DESCRIPTION
One of the first things cdflow does is to pull the cdflow-commands
container using the docker python library. This needed additional work
to handle auth correctly.

Going forward cdflow supports two methods for providing that auth.
Either the existence of a docker config file at ~/.docker/config.json
(which can be overridden with the DOCKER_CONFIG environment var)
Or by supplying both the DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD
environment variables.

The environment vars take precedance over the docker config file.

If using some sort of credential store for your docker config file you
will need to use the environment vars.

Whichever is used to download the cdflow-commands container is also
what's used to populate /root/.docker/config.json within the
cdflow-commands container